### PR TITLE
Clean up "post notifications permission" implementation.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -199,7 +199,6 @@ dependencies {
     implementation project(":network")
     implementation project(":engelsystem")
 
-    api "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1" // Added to Resolve Dependency Error -> https://issuetracker.google.com/issues/238425626#comment11
     implementation Libs.appCompat
     implementation Libs.betterLinkMovementMethod
     implementation Libs.constraintLayout

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/details/SessionDetailsViewModel.kt
@@ -1,6 +1,5 @@
 package nerd.tuxmobil.fahrplan.congress.details
 
-import android.content.Context
 import android.net.Uri
 import android.os.Build
 import androidx.core.net.toUri
@@ -43,7 +42,8 @@ internal class SessionDetailsViewModel(
     private val formattingDelegate: FormattingDelegate = DateFormattingDelegate(),
     private val c3NavBaseUrl: String,
     private val defaultEngelsystemRoomName: String,
-    private val customEngelsystemRoomName: String
+    private val customEngelsystemRoomName: String,
+    private val runsAtLeastOnAndroidTiramisu: Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
 
 ) : ViewModel() {
 
@@ -95,7 +95,8 @@ internal class SessionDetailsViewModel(
     val setAlarm = SingleLiveEvent<Unit>()
     val navigateToRoom = SingleLiveEvent<Uri>()
     val closeDetails = SingleLiveEvent<Unit>()
-    val checkNotificationPermission = SingleLiveEvent<Boolean>()
+    val requestPostNotificationsPermission = SingleLiveEvent<Unit>()
+    val missingPostNotificationsPermission = SingleLiveEvent<Unit>()
 
     private fun SelectedSessionParameter.customizeEngelsystemRoomName() = copy(
         roomName = if (roomName == defaultEngelsystemRoomName) customEngelsystemRoomName else roomName
@@ -194,7 +195,10 @@ internal class SessionDetailsViewModel(
         if (notificationHelper.notificationsEnabled) {
             setAlarm.postValue(Unit)
         } else {
-            checkNotificationPermission.postValue(Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+            when (runsAtLeastOnAndroidTiramisu) {
+                true -> requestPostNotificationsPermission.postValue(Unit)
+                false -> missingPostNotificationsPermission.postValue(Unit)
+            }
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/notifications/NotificationHelper.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/notifications/NotificationHelper.kt
@@ -6,7 +6,6 @@ import android.content.Context
 import android.content.ContextWrapper
 import android.net.Uri
 import androidx.core.app.NotificationChannelCompat
-import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
@@ -18,6 +17,8 @@ internal class NotificationHelper(context: Context) : ContextWrapper(context) {
     private val notificationManager: NotificationManagerCompat by lazy {
         getNotificationManager()
     }
+
+    val notificationsEnabled = notificationManager.areNotificationsEnabled()
 
     init {
         createChannels()
@@ -93,13 +94,6 @@ internal class NotificationHelper(context: Context) : ContextWrapper(context) {
                     .setPriority(NotificationCompat.PRIORITY_DEFAULT)
                     .setSmallIcon(smallIcon)
                     .setSound(sound)
-
-    val notificationsEnabled: Boolean
-        get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            notificationManager.areNotificationsEnabled()
-        } else {
-            true
-        }
 
     private val sessionAlarmChannelDescription: String
         get() = getString(R.string.notifications_session_alarm_channel_description)

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainActivity.kt
@@ -97,10 +97,7 @@ class MainActivity : BaseActivity(),
     private lateinit var progressBar: ContentLoadingProgressBar
     private var progressDialog: ProgressDialog? = null
     private val viewModel: MainViewModel by viewModels {
-        MainViewModelFactory(
-            repository = AppRepository,
-            notificationHelper = notificationHelper
-        )
+        MainViewModelFactory(AppRepository, notificationHelper)
     }
 
     private var isScreenLocked = false
@@ -117,7 +114,7 @@ class MainActivity : BaseActivity(),
         instance = this
         setContentView(R.layout.main_layout)
 
-        notificationHelper = NotificationHelper(applicationContext)
+        notificationHelper = NotificationHelper(this)
 
         keyguardManager = getSystemService()!!
         errorMessageFactory = ErrorMessage.Factory(this)
@@ -144,7 +141,7 @@ class MainActivity : BaseActivity(),
         initUserEngagement()
         observeViewModel()
         onSessionAlarmNotificationTapped(intent)
-        viewModel.checkNotificationPermissions()
+        viewModel.checkPostNotificationsPermission()
     }
 
     private fun observeViewModel() {
@@ -171,8 +168,8 @@ class MainActivity : BaseActivity(),
         viewModel.openSessionDetails.observe(this) {
             openSessionDetails()
         }
-        viewModel.showNotificationsDisclaimer.observe(this) {
-            Toast.makeText(baseContext, R.string.alarm_disabled_toast, Toast.LENGTH_LONG).show()
+        viewModel.missingPostNotificationsPermission.observe(this) {
+            Toast.makeText(this, R.string.alarms_disabled_notifications_permission_missing, Toast.LENGTH_LONG).show()
         }
     }
 

--- a/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainViewModel.kt
+++ b/app/src/main/java/nerd/tuxmobil/fahrplan/congress/schedule/MainViewModel.kt
@@ -40,7 +40,7 @@ internal class MainViewModel(
 
     val showAbout = SingleLiveEvent<Meta>()
     val openSessionDetails = SingleLiveEvent<Unit>()
-    val showNotificationsDisclaimer = SingleLiveEvent<Unit>()
+    val missingPostNotificationsPermission = SingleLiveEvent<Unit>()
 
     init {
         observeLoadScheduleState()
@@ -138,9 +138,9 @@ internal class MainViewModel(
         }
     }
 
-    fun checkNotificationPermissions(){
-        if(repository.readAlarms().isNotEmpty() && !notificationHelper.notificationsEnabled) {
-            showNotificationsDisclaimer.postValue(Unit)
+    fun checkPostNotificationsPermission() {
+        if (repository.readAlarms().isNotEmpty() && !notificationHelper.notificationsEnabled) {
+            missingPostNotificationsPermission.postValue(Unit)
         }
     }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -206,7 +206,7 @@
     <string name="alarm_time_title_45_minutes_before">45 Minuten vorher</string>
     <string name="alarm_time_title_60_minutes_before">60 Minuten vorher</string>
 
-    <string name="alarm_disabled_toast">Alarme deaktiviert da die Benachrichtigungs Berechtigung fehlt</string>
+    <string name="alarms_disabled_notifications_permission_missing">Alarme sind deaktiviert. Bitte erteile die \"Benachrichtigungen\" Berechtigung.</string>
 
     <!-- Session list item -->
     <string name="session_list_item_alarm_time_zero_minutes_content_description">Alarm: zur Startzeit</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -236,7 +236,7 @@
     <string name="alarm_time_title_45_minutes_before">45 minutes before</string>
     <string name="alarm_time_title_60_minutes_before">60 minutes before</string>
 
-    <string name="alarm_disabled_toast">Alarms are disabled, please grant the notification permission to re-enable</string>
+    <string name="alarms_disabled_notifications_permission_missing">Alarms are disabled. Please grant the \"Notifications\" permission.</string>
 
     <!-- Session list item -->
     <string name="session_list_item_alarm_time_zero_minutes_content_description">Alarm: at start time</string>


### PR DESCRIPTION
# Main changes
+ Simplify NotificationHelper.
+ Move logic into view models - keep fragment / activity stupid.
+ Cover view models with unit tests.
+ Remove unneeded lifecycle-viewmodel-ktx dependency.
+ Fix usage of context.

:arrow_down: To be squashed into the former commit.